### PR TITLE
CIエラーを修復: テスト環境でActive Storageのvariant処理を無効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git pkg-config google-chrome-stable
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git pkg-config google-chrome-stable libvips
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git pkg-config google-chrome-stable libvips
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git pkg-config google-chrome-stable
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,11 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # No variant processing is used in the test suite; disabling it avoids requiring
+  # libvips to be installed just to boot the app (Rails 8.1.3.1 loads the configured
+  # variant processor eagerly at boot to call Vips.block_untrusted).
+  config.active_storage.variant_processor = :disabled
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.


### PR DESCRIPTION
## 概要

- PR #120（Rails 8.1.3 → 8.1.3.1 へのバンプ）で CI の `test` ジョブが失敗していた問題を修正
- 原因: Rails 8.1.3.1 では、セキュリティ修正（libvipsの未fuzzテストなローダー/セーバーを無効化するため `Vips.block_untrusted(true)` を呼ぶ）により、Active Storage が起動時に設定された variant processor（デフォルトは `:vips`）を即座にロードするようになった。その結果、`bin/rails db:test:prepare` などアプリを起動するだけで `libvips` のネイティブ共有ライブラリ（`libvips.so.42`）が必要になり、それがインストールされていない CI ランナー上で `LoadError` が発生していた
- 本リポジトリのテストスイートは `.variant(...)` を一切使用していない（`has_one_attached :featured_image` のみ）ため、テスト環境では variant processor 自体が不要
- そのため `config/environments/test.rb` で `config.active_storage.variant_processor = :disabled` を設定し、no-op の `NullTransformer` を使うようにして `libvips` への依存を回避する方針にした（CI 側に `libvips` をインストールする案も検討したが、テスト環境で不要な依存を追加しないこちらの方針を採用）

## 変更内容

- `config/environments/test.rb`: `config.active_storage.variant_processor = :disabled` を追加

## テスト計画

- [x] CI の `test` ジョブが成功することを確認