### PR TITLE
Auto-merge Dependabot patch updates after CI passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,29 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+  dependabot_auto_merge:
+    runs-on: ubuntu-latest
+
+    # Runs only after every other job above has succeeded, so a PR is merged
+    # only when CI is fully green.
+    needs: [ scan_ruby, scan_js, lint, test ]
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge patch-level updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a dependabot_auto_merge job to the CI workflow. It depends on every
other CI job, so it only runs once the whole suite is green, and it uses
dependabot/fetch-metadata to merge only version-update:semver-patch PRs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RtedWk6nAipEHKcVsPVuBs